### PR TITLE
Add more original context to HTTP exception

### DIFF
--- a/src/Exceptions/MatrixHttpLibException.php
+++ b/src/Exceptions/MatrixHttpLibException.php
@@ -12,6 +12,6 @@ class MatrixHttpLibException extends MatrixException {
     public function __construct(\Exception $originalException, string $method, string $endpoint) {
         $msg = "Something went wrong in %s requesting %s: %s";
         $msg = sprintf($msg, $method, $endpoint, $originalException);
-        parent::__construct($msg);
+        parent::__construct($msg, $originalException->getCode(), $originalException);
     }
 }


### PR DESCRIPTION
## Description

Adds the original code and exception to the `MatrixHttpLibException`.

## Motivation and context

It's helpful for try-catch clauses to have access to the original code and exception from the transport error.

## How has this been tested?

Local functional testing.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Debatable if this is BC break, but this does reveal codes other than 0 in the Exception.