### PR TITLE
Make MatrixHttpApi->send public

### DIFF
--- a/src/MatrixHttpApi.php
+++ b/src/MatrixHttpApi.php
@@ -900,8 +900,8 @@ class MatrixHttpApi {
      * @throws MatrixRequestException
      * @throws MatrixHttpLibException
      */
-    private function send(string $method, string $path, $content = null, array $queryParams = [], array $headers = [],
-                          $apiPath = self::MATRIX_V2_API_PATH, $returnJson = true) {
+    public function send(string $method, string $path, $content = null, array $queryParams = [], array $headers = [],
+                         string $apiPath = self::MATRIX_V2_API_PATH, bool $returnJson = true) {
         $options = [];
         if (!in_array('User-Agent', $headers)) {
             $headers['User-Agent'] = 'php-matrix-sdk/' . self::VERSION;


### PR DESCRIPTION
## Description

Makes the send function in MatrixHttpApi public for library access.

## Motivation and context

I wanted to register users via the synapse admin API. Using the send function it is as easy as:

```php
$nonceResponse = $this->client->api()->send(
    'GET',
    '/register',
    null,
    [],
    [],
    '/_synapse/admin/v1',
    true
);
$hmacData = $nonceResponse["nonce"] . "\x00" . $username . "\x00" . $password . "\x00notadmin";
$hmac = hash_hmac("sha1", $hmacData, $this->registrationSecret, false);
$registrationResponse = $this->client->api()->send(
    'POST',
    '/register',
    array(
        "nonce" => $nonceResponse["nonce"],
        "username" => $username,
        "password" => $password,
        "admin" => false,
        "mac" => $hmac,
    ),
    [],
    [],
    '/_synapse/admin/v1',
    true
);
```

## How has this been tested?

Please describe in detail how you tested your changes.

I successfully ran the code in the previous section.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

Please guide me through the last two steps, if those are necessary.
